### PR TITLE
feat: mobile/tablet responsiveness (#17)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -22,6 +22,7 @@ Guided runner for Scrum ceremonies (planning, daily, review, retro): time-boxed 
 - [x] Unified header — `AppHeader.tsx` + `LanguagePicker.tsx` from design system replace inline header; white sticky h-14 header; dropdown language picker (EN/ES/BE/RU); dashboard grid-icon link
 - [x] Light/dark theme — `darkMode: 'class'` in tailwind.config.js; anti-flash inline script in index.html; `ThemeToggle.tsx` from design system in AppHeader children slot; `dark:` variants across all components and retro board colour configs; preference persisted via `theme` localStorage key
 - [x] Keyboard shortcuts — `Space` start/pause timer; `ArrowLeft`/`ArrowRight` prev/next step; `R` reset timer; `M` mute toggle; `useEffect` with `keydown` listener in CeremonyRunner; ref pattern to avoid stale closures; keyboard hint bar shown below navigation; `keyboard.*` i18n keys in all 4 locales
+- [x] Mobile/tablet responsiveness — `CountdownTimer` uses `viewBox` + `w-full max-w-[120px]` (scales on narrow viewports); `StickyColumn` accordion on mobile (`hidden md:flex` body, collapse/expand chevron); delete buttons always visible on mobile (`opacity-100 md:opacity-0 md:group-hover:opacity-100`); `ParticipantPanel` 44 × 44 px min tap targets; `CeremonyRunner` stacks timer above step title on mobile (`flex-col sm:flex-row`); keyboard hint hidden on mobile (`hidden sm:flex`)
 
 ## Backlog
 
@@ -35,12 +36,19 @@ Guided runner for Scrum ceremonies (planning, daily, review, retro): time-boxed 
 - [x] [#18] Unify header: AppHeader component + LanguagePicker — implemented
 - [x] [#19] Feature: light/dark theme support (ThemeToggle + dark: Tailwind variants) — implemented
 - [x] [#16] Feature: Keyboard shortcuts for ceremony runner — implemented
+- [x] [#17] Research: Mobile/tablet responsiveness — implemented
 
 ## Tech notes
 
 - Root `README.md` still has HTML comment TODO for screenshots (non-blocking).
 
 ## Agent Log
+
+### 2026-05-31 — feat: mobile/tablet responsiveness (#17)
+- Done: `CountdownTimer.tsx` — SVG uses `viewBox` + `w-full max-w-[120px]` wrapper (scales to any narrow viewport); `StickyColumn.tsx` — accordion on mobile with header button toggle (`hidden md:flex` body, `▲/▼` caret visible below `md`); `StickyNote.tsx` — delete ✕ always visible on mobile (`opacity-100 md:opacity-0 md:group-hover:opacity-100`), min 28×28 px touch area; `ParticipantPanel.tsx` — participant rows `min-h-[44px]`, remove button `min-w-[36px] min-h-[36px]`, always visible on mobile; `CeremonyRunner.tsx` — timer+title stacks vertically on mobile (`flex-col sm:flex-row`), keyboard hint bar hidden below `sm` (`hidden sm:flex`)
+- Issue #17 set to In Review
+- Remaining approved: #15 (Dashboard card)
+- Next task: implement #15 (Dashboard card — surface active session and last ceremony from scrum-facilitator-session and scrum-facilitator-history localStorage keys)
 
 ### 2026-05-30 — feat: keyboard shortcuts (#16)
 - Done: `useEffect` keydown listener in `CeremonyRunner.tsx`; `shortcutsRef` pattern keeps latest handlers without stale closures; Space=start/pause, ArrowRight=next, ArrowLeft=prev, R=reset, M=mute; skips events from INPUT/TEXTAREA; `Kbd` helper component for key badges; keyboard hint bar below navigation buttons; `keyboard.space/arrows/r/m` i18n keys added to EN/ES/BE/RU

--- a/src/components/CeremonyRunner.tsx
+++ b/src/components/CeremonyRunner.tsx
@@ -199,16 +199,18 @@ export default function CeremonyRunner({
       </div>
 
       {/* Step card */}
-      <div className="card p-6 flex flex-col gap-5">
-        <div className="flex items-start gap-4">
+      <div className="card p-4 sm:p-6 flex flex-col gap-5">
+        <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">
           {/* Timer */}
-          <CountdownTimer
-            timeRemaining={timeRemaining}
-            percentLeft={percentLeft}
-            timerState={timerState}
-          />
+          <div className="w-24 sm:w-auto flex-shrink-0">
+            <CountdownTimer
+              timeRemaining={timeRemaining}
+              percentLeft={percentLeft}
+              timerState={timerState}
+            />
+          </div>
           {/* Step info */}
-          <div className="flex-1">
+          <div className="flex-1 text-center sm:text-left">
             <h3 className="text-xl font-bold text-gray-900 dark:text-gray-50">{t(currentStep.titleKey)}</h3>
             <span className="inline-block mt-1 text-xs font-medium bg-brand-50 dark:bg-brand-700/20 text-brand-600 dark:text-brand-400 px-2 py-0.5 rounded-full">
               {formatDuration(currentStep.duration)}
@@ -312,8 +314,8 @@ export default function CeremonyRunner({
         </button>
       </div>
 
-      {/* Keyboard shortcuts hint */}
-      <div className="flex flex-wrap gap-x-4 gap-y-1.5 justify-center text-xs text-gray-400 dark:text-gray-500">
+      {/* Keyboard shortcuts hint — hidden on touch-primary devices */}
+      <div className="hidden sm:flex flex-wrap gap-x-4 gap-y-1.5 justify-center text-xs text-gray-400 dark:text-gray-500">
         <span><Kbd>Space</Kbd> {t('keyboard.space')}</span>
         <span><Kbd>←</Kbd><Kbd>→</Kbd> {t('keyboard.arrows')}</span>
         <span><Kbd>R</Kbd> {t('keyboard.r')}</span>

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -25,8 +25,12 @@ export default function CountdownTimer({ timeRemaining, percentLeft, timerState 
 
   return (
     <div className="flex flex-col items-center gap-1">
-      <div className={`relative${isDone ? ' animate-pulse' : ''}`} style={{ width: SIZE, height: SIZE }}>
-        <svg width={SIZE} height={SIZE} className="-rotate-90 text-gray-200 dark:text-gray-700">
+      <div className={`relative w-full max-w-[120px]${isDone ? ' animate-pulse' : ''}`}>
+        <svg
+          viewBox={`0 0 ${SIZE} ${SIZE}`}
+          className="-rotate-90 w-full h-auto text-gray-200 dark:text-gray-700"
+          aria-hidden="true"
+        >
           {/* Track */}
           <circle
             cx={SIZE / 2}

--- a/src/components/ParticipantPanel.tsx
+++ b/src/components/ParticipantPanel.tsx
@@ -82,21 +82,21 @@ export default function ParticipantPanel({ participants, onChange }: Props) {
           {participants.map(p => (
             <div
               key={p.id}
-              className={`flex items-center gap-3 px-3 py-2 rounded-xl border cursor-pointer transition-all ${statusColor(p.status)}`}
+              className={`flex items-center gap-3 px-3 py-2 min-h-[44px] rounded-xl border cursor-pointer transition-all ${statusColor(p.status)}`}
               onClick={() => advanceStatus(p.id)}
               role="button"
               tabIndex={0}
               onKeyDown={e => e.key === 'Enter' && advanceStatus(p.id)}
               aria-label={`${p.name} — ${t(`daily.status.${p.status}`)}`}
             >
-              <div className="w-8 h-8 rounded-full bg-current bg-opacity-10 flex items-center justify-center text-sm font-bold flex-shrink-0">
+              <div className="w-9 h-9 rounded-full bg-current bg-opacity-10 flex items-center justify-center text-sm font-bold flex-shrink-0">
                 {p.status === 'done' ? '✓' : p.name[0]?.toUpperCase()}
               </div>
               <span className="flex-1 text-sm font-medium">{p.name}</span>
               <span className="text-xs opacity-70">{t(`daily.status.${p.status}`)}</span>
               <button
                 onClick={e => { e.stopPropagation(); removeParticipant(p.id) }}
-                className="opacity-40 hover:opacity-100 text-sm ml-1"
+                className="min-w-[36px] min-h-[36px] flex items-center justify-center opacity-100 md:opacity-40 md:hover:opacity-100 text-sm ml-1"
                 aria-label={t('common.delete')}
               >
                 ×

--- a/src/components/StickyColumn.tsx
+++ b/src/components/StickyColumn.tsx
@@ -20,6 +20,7 @@ export default function StickyColumn({
 }: Props) {
   const { t } = useTranslation()
   const [draft, setDraft] = useState('')
+  const [open, setOpen] = useState(false)
 
   const submit = () => {
     const trimmed = draft.trim()
@@ -30,36 +31,47 @@ export default function StickyColumn({
 
   return (
     <div className="flex flex-col gap-3 min-w-0">
-      <div className={`flex items-center gap-2 px-3 py-2 rounded-xl ${headerColor}`}>
+      {/* Header — tappable on mobile to collapse/expand; non-interactive on md+ */}
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className={`flex items-center gap-2 px-3 py-2 rounded-xl w-full text-left ${headerColor}`}
+        aria-expanded={open}
+      >
         <span className="font-semibold text-sm flex-1">{t(labelKey)}</span>
         <span className="text-xs font-medium opacity-70 bg-white bg-opacity-50 rounded-full px-2 py-0.5">
           {notes.length}
         </span>
-      </div>
+        {/* Caret visible only on mobile */}
+        <span className="md:hidden text-xs opacity-60 ml-1">{open ? '▲' : '▼'}</span>
+      </button>
 
-      <div className="flex flex-col gap-2 flex-1">
-        {notes.map(note => (
-          <StickyNote
-            key={note.id}
-            note={note}
-            colorClass={colorClass}
-            onEdit={(id, text) => onEdit(column, id, text)}
-            onDelete={id => onDelete(column, id)}
+      {/* Body — hidden on mobile when closed, always visible on md+ */}
+      <div className={`flex-col gap-2 flex-1 ${open ? 'flex' : 'hidden md:flex'}`}>
+        <div className="flex flex-col gap-2 flex-1">
+          {notes.map(note => (
+            <StickyNote
+              key={note.id}
+              note={note}
+              colorClass={colorClass}
+              onEdit={(id, text) => onEdit(column, id, text)}
+              onDelete={id => onDelete(column, id)}
+            />
+          ))}
+        </div>
+
+        <div className="flex gap-2">
+          <input
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && submit()}
+            placeholder={t('retro.addPlaceholder')}
+            className="flex-1 border border-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-400"
           />
-        ))}
-      </div>
-
-      <div className="flex gap-2">
-        <input
-          value={draft}
-          onChange={e => setDraft(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && submit()}
-          placeholder={t('retro.addPlaceholder')}
-          className="flex-1 border border-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-400"
-        />
-        <button onClick={submit} disabled={!draft.trim()} className="btn-primary text-sm py-2 px-3">
-          +
-        </button>
+          <button onClick={submit} disabled={!draft.trim()} className="btn-primary text-sm py-2 px-3 min-w-[44px] min-h-[44px]">
+            +
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/src/components/StickyNote.tsx
+++ b/src/components/StickyNote.tsx
@@ -68,7 +68,7 @@ export default function StickyNote({ note, colorClass, onEdit, onDelete }: Props
           e.stopPropagation()
           if (window.confirm(t('retro.deleteConfirm'))) onDelete(note.id)
         }}
-        className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-all text-sm"
+        className="absolute top-2 right-2 min-w-[28px] min-h-[28px] flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-all text-sm"
         aria-label={t('common.delete')}
       >
         ×


### PR DESCRIPTION
Automated agent commit — see BRIEF.md.

Implements #17 — mobile/tablet responsiveness:

- **CountdownTimer**: SVG uses `viewBox` + responsive wrapper (`w-full max-w-[120px]`) — scales correctly on any viewport including iPhone SE (375px)
- **StickyColumn**: accordion on mobile — header is tappable to collapse/expand body; `hidden md:flex` hides body below md breakpoint; `▲/▼` caret visible only on mobile
- **StickyNote**: delete ✕ always visible on mobile (`opacity-100 md:opacity-0 md:group-hover:opacity-100`), minimum 28×28px touch area
- **ParticipantPanel**: participant rows `min-h-[44px]` (WCAG 2.5.5), remove button `min-w-[36px] min-h-[36px]` and always visible on mobile
- **CeremonyRunner**: timer+title stacks vertically on mobile (`flex-col sm:flex-row`); keyboard hint bar hidden below `sm` (keyboard shortcuts are irrelevant on touch devices)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYY2a9oTdUVjFLi3ocbVgj)_