### PR TITLE
feat: named ceremony history — label sessions by team (#24)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -23,6 +23,7 @@ Guided runner for Scrum ceremonies (planning, daily, review, retro): time-boxed 
 - [x] Light/dark theme — `darkMode: 'class'` in tailwind.config.js; anti-flash inline script in index.html; `ThemeToggle.tsx` from design system in AppHeader children slot; `dark:` variants across all components and retro board colour configs; preference persisted via `theme` localStorage key
 - [x] Keyboard shortcuts — `Space` start/pause timer; `ArrowLeft`/`ArrowRight` prev/next step; `R` reset timer; `M` mute toggle; `useEffect` with `keydown` listener in CeremonyRunner; ref pattern to avoid stale closures; keyboard hint bar shown below navigation; `keyboard.*` i18n keys in all 4 locales
 - [x] Mobile/tablet responsiveness — `CountdownTimer` uses `viewBox` + `w-full max-w-[120px]` (scales on narrow viewports); `StickyColumn` accordion on mobile (`hidden md:flex` body, collapse/expand chevron); delete buttons always visible on mobile (`opacity-100 md:opacity-0 md:group-hover:opacity-100`); `ParticipantPanel` 44 × 44 px min tap targets; `CeremonyRunner` stacks timer above step title on mobile (`flex-col sm:flex-row`); keyboard hint hidden on mobile (`hidden sm:flex`)
+- [x] Named ceremony history — optional `teamName` text input on HomeScreen (persists to `scrum-facilitator-team-name` localStorage); recent team names shown as pill chips; history entries show `Team · Ceremony` format when team is set; resume banner shows team name; CeremonyRunner header shows team name; export Markdown title includes team name; all 4 locales (EN/ES/BE/RU)
 
 ## Backlog
 
@@ -37,12 +38,32 @@ Guided runner for Scrum ceremonies (planning, daily, review, retro): time-boxed 
 - [x] [#19] Feature: light/dark theme support (ThemeToggle + dark: Tailwind variants) — implemented
 - [x] [#16] Feature: Keyboard shortcuts for ceremony runner — implemented
 - [x] [#17] Research: Mobile/tablet responsiveness — implemented
+- [x] [#24] Feature: Named ceremony history — label sessions by team/sprint — implemented
+- [ ] [#15] Integration: Dashboard card — surface active session and last ceremony
+
+## localStorage keys
+
+| Key | Content |
+|-----|---------|
+| `scrum-facilitator-session` | `{ ceremonyType, stepIndex, completedSteps, participants, retroNotes, retroFormat, teamName?, savedAt }` — auto-saved during ceremony, cleared on complete |
+| `scrum-facilitator-history` | Array (max 5) of `{ id, exportData, savedAt }` — completed ceremony summaries |
+| `scrum-facilitator-retro-format` | `RetroFormat` string — selected retro format |
+| `scrum-facilitator-muted` | `'true'` or `'false'` — timer alert mute preference |
+| `scrum-facilitator-team-name` | string — last-used team/label name |
+| `sf_participants` | `Participant[]` — Daily Scrum participant list |
+| `theme` | `'dark'` or `'light'` — theme preference |
 
 ## Tech notes
 
 - Root `README.md` still has HTML comment TODO for screenshots (non-blocking).
 
 ## Agent Log
+
+### 2026-06-07 — feat: named ceremony history (#24)
+- Done: `types.ts` — `teamName?: string` added to `SessionState` and `ExportData`; `App.tsx` — `scrum-facilitator-team-name` localStorage key via `useLocalStorage`, `recentTeamNames` derived from history, teamName passed to `HomeScreen` and `CeremonyRunner`; `HomeScreen.tsx` — "Team / Label (optional)" text input with recent-name pill chips; history entries show `Team · Ceremony` when team set; resume banner uses `resumePromptTeam` i18n key when teamName present; `CeremonyRunner.tsx` — `teamName` prop included in session auto-save and shown in ceremony header; `ExportView.tsx` — Markdown title includes team name; `en/es/be/ru.json` — `team.label`, `team.placeholder`, `history.resumePromptTeam` keys added
+- Issue #24 set to In Review
+- Remaining approved: #15 (Dashboard card — requires agile-toolkit.github.io changes, separate run)
+- Next task: check issues for human feedback; implement #15 (Dashboard card for scrum-facilitator — dashboard reads `scrum-facilitator-session` + `scrum-facilitator-history` keys)
 
 ### 2026-05-31 — feat: mobile/tablet responsiveness (#17)
 - Done: `CountdownTimer.tsx` — SVG uses `viewBox` + `w-full max-w-[120px]` wrapper (scales to any narrow viewport); `StickyColumn.tsx` — accordion on mobile with header button toggle (`hidden md:flex` body, `▲/▼` caret visible below `md`); `StickyNote.tsx` — delete ✕ always visible on mobile (`opacity-100 md:opacity-0 md:group-hover:opacity-100`), min 28×28 px touch area; `ParticipantPanel.tsx` — participant rows `min-h-[44px]`, remove button `min-w-[36px] min-h-[36px]`, always visible on mobile; `CeremonyRunner.tsx` — timer+title stacks vertically on mobile (`flex-col sm:flex-row`), keyboard hint bar hidden below `sm` (`hidden sm:flex`)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import ThemeToggle from './components/ThemeToggle'
 
 const SESSION_KEY = 'scrum-facilitator-session'
 const HISTORY_KEY = 'scrum-facilitator-history'
+const TEAM_NAME_KEY = 'scrum-facilitator-team-name'
 
 interface AppState {
   screen: Screen
@@ -38,6 +39,7 @@ export default function App() {
 
   const [history, setHistory] = useLocalStorage<HistoryEntry[]>(HISTORY_KEY, [])
   const [retroFormat, setRetroFormat] = useLocalStorage<RetroFormat>('scrum-facilitator-retro-format', 'classic')
+  const [teamName, setTeamName] = useLocalStorage<string>(TEAM_NAME_KEY, '')
   const [dismissedResume, setDismissedResume] = useState(false)
 
   const [appState, setAppState] = useState<AppState>({
@@ -68,6 +70,7 @@ export default function App() {
     if (!sessionOnMount) return
     setRetroNotes(sessionOnMount.retroNotes)
     if (sessionOnMount.retroFormat) setRetroFormat(sessionOnMount.retroFormat)
+    if (sessionOnMount.teamName !== undefined) setTeamName(sessionOnMount.teamName)
     setDismissedResume(true)
     setAppState({ screen: 'ceremony', ceremonyType: sessionOnMount.ceremonyType, exportData: null, resumeSession: sessionOnMount, exportBackScreen: 'complete' })
   }
@@ -82,6 +85,7 @@ export default function App() {
     const data: ExportData = {
       ceremonyType: appState.ceremonyType!,
       date: new Date().toLocaleDateString(),
+      teamName: teamName.trim() || undefined,
       participants,
       retroNotes: appState.ceremonyType === 'retro' ? retroNotes : undefined,
       retroFormat: appState.ceremonyType === 'retro' ? retroFormat : undefined,
@@ -106,6 +110,10 @@ export default function App() {
     setAppState({ screen: 'home', ceremonyType: null, exportData: null, resumeSession: null, exportBackScreen: 'complete' })
   }
 
+  const recentTeamNames = Array.from(
+    new Set(history.map(e => e.exportData.teamName).filter((n): n is string => Boolean(n)))
+  ).slice(0, 5)
+
   const showResumeBanner = !dismissedResume && sessionOnMount !== null
 
   return (
@@ -118,6 +126,9 @@ export default function App() {
             onSelect={startCeremony}
             retroFormat={retroFormat}
             onRetroFormatChange={setRetroFormat}
+            teamName={teamName}
+            onTeamNameChange={setTeamName}
+            recentTeamNames={recentTeamNames}
             session={showResumeBanner ? sessionOnMount : null}
             onResume={resumeCeremony}
             onDiscard={discardSession}
@@ -130,6 +141,7 @@ export default function App() {
             ceremonyType={appState.ceremonyType}
             retroNotes={retroNotes}
             retroFormat={retroFormat}
+            teamName={teamName.trim() || undefined}
             onRetroNotesChange={setRetroNotes}
             onComplete={completeCeremony}
             onBack={goHome}

--- a/src/components/CeremonyRunner.tsx
+++ b/src/components/CeremonyRunner.tsx
@@ -44,6 +44,7 @@ interface Props {
   ceremonyType: CeremonyType
   retroNotes: RetroNotes
   retroFormat: RetroFormat
+  teamName?: string
   onRetroNotesChange: (n: RetroNotes) => void
   onComplete: (stepsCompleted: number, participants?: string[]) => void
   onBack: () => void
@@ -51,7 +52,7 @@ interface Props {
 }
 
 export default function CeremonyRunner({
-  ceremonyType, retroNotes, retroFormat, onRetroNotesChange, onComplete, onBack, resumeSession,
+  ceremonyType, retroNotes, retroFormat, teamName, onRetroNotesChange, onComplete, onBack, resumeSession,
 }: Props) {
   const { t } = useTranslation()
   const ceremony = getCeremony(ceremonyType)
@@ -101,10 +102,11 @@ export default function CeremonyRunner({
       participants,
       retroNotes,
       retroFormat,
+      teamName,
       savedAt: Date.now(),
     }
     try { localStorage.setItem(SESSION_KEY, JSON.stringify(session)) } catch { /* ignore */ }
-  }, [stepIndex, completedSteps, retroNotes, participants, ceremonyType])
+  }, [stepIndex, completedSteps, retroNotes, participants, ceremonyType, teamName])
 
   const isFirst = stepIndex === 0
   const isLast = ceremony ? stepIndex === ceremony.steps.length - 1 : false
@@ -173,7 +175,9 @@ export default function CeremonyRunner({
       <div className="flex items-center gap-3">
         <button onClick={onBack} className="btn-ghost">← {t('common.back')}</button>
         <div className="flex-1">
-          <h2 className="font-bold text-gray-900 dark:text-gray-50 text-lg">{t(ceremony.nameKey)}</h2>
+          <h2 className="font-bold text-gray-900 dark:text-gray-50 text-lg">
+            {teamName ? `${teamName} · ${t(ceremony.nameKey)}` : t(ceremony.nameKey)}
+          </h2>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {t('ceremony.stepOf', { current: stepIndex + 1, total: ceremony.steps.length })}
           </p>

--- a/src/components/ExportView.tsx
+++ b/src/components/ExportView.tsx
@@ -22,8 +22,9 @@ interface Props {
 function buildMarkdown(data: ExportData, t: (k: string, opts?: Record<string, unknown>) => string): string {
   const ceremony = CEREMONIES.find(c => c.type === data.ceremonyType)
   const name = ceremony ? t(ceremony.nameKey) : data.ceremonyType
+  const title = data.teamName ? `${name} — ${data.teamName}` : name
   const lines: string[] = [
-    `# ${name}`,
+    `# ${title}`,
     `**Date:** ${data.date}`,
     `**Steps completed:** ${data.stepsCompleted} / ${data.totalSteps}`,
   ]

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -15,6 +15,9 @@ interface Props {
   onSelect: (type: CeremonyType) => void
   retroFormat: RetroFormat
   onRetroFormatChange: (f: RetroFormat) => void
+  teamName: string
+  onTeamNameChange: (name: string) => void
+  recentTeamNames: string[]
   session: SessionState | null
   onResume: () => void
   onDiscard: () => void
@@ -22,7 +25,11 @@ interface Props {
   onViewHistory: (entry: HistoryEntry) => void
 }
 
-export default function HomeScreen({ onSelect, retroFormat, onRetroFormatChange, session, onResume, onDiscard, history, onViewHistory }: Props) {
+export default function HomeScreen({
+  onSelect, retroFormat, onRetroFormatChange,
+  teamName, onTeamNameChange, recentTeamNames,
+  session, onResume, onDiscard, history, onViewHistory,
+}: Props) {
   const { t } = useTranslation()
 
   const ceremonyName = (type: CeremonyType) => {
@@ -36,7 +43,9 @@ export default function HomeScreen({ onSelect, retroFormat, onRetroFormatChange,
       {session && (
         <div className="rounded-lg bg-brand-50 dark:bg-gray-800 border border-brand-100 dark:border-gray-600 px-4 py-3 flex items-center justify-between gap-4 flex-wrap">
           <span className="text-sm text-gray-800 dark:text-gray-200">
-            {t('history.resumePrompt', { ceremony: ceremonyName(session.ceremonyType), ago: timeAgo(session.savedAt) })}
+            {session.teamName
+              ? t('history.resumePromptTeam', { ceremony: ceremonyName(session.ceremonyType), team: session.teamName, ago: timeAgo(session.savedAt) })
+              : t('history.resumePrompt', { ceremony: ceremonyName(session.ceremonyType), ago: timeAgo(session.savedAt) })}
           </span>
           <div className="flex gap-2 flex-shrink-0">
             <button onClick={onResume} className="btn-primary text-sm">
@@ -52,6 +61,37 @@ export default function HomeScreen({ onSelect, retroFormat, onRetroFormatChange,
       <div className="text-center">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-50">{t('home.title')}</h1>
         <p className="text-gray-500 dark:text-gray-400 mt-2">{t('home.subtitle')}</p>
+      </div>
+
+      {/* Team name input */}
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-gray-600 dark:text-gray-400">
+          {t('team.label')}
+        </label>
+        <input
+          type="text"
+          value={teamName}
+          onChange={e => onTeamNameChange(e.target.value)}
+          placeholder={t('team.placeholder')}
+          className="w-full sm:w-72 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 text-sm placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-brand-400 dark:focus:ring-brand-500"
+        />
+        {recentTeamNames.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {recentTeamNames.map(name => (
+              <button
+                key={name}
+                onClick={() => onTeamNameChange(name)}
+                className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                  name === teamName
+                    ? 'bg-brand-500 text-white border-brand-500'
+                    : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-600 hover:border-brand-300 hover:text-brand-600'
+                }`}
+              >
+                {name}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -101,7 +141,9 @@ export default function HomeScreen({ onSelect, retroFormat, onRetroFormatChange,
                   </span>
                   <div className="min-w-0">
                     <p className="text-sm font-medium text-gray-800 dark:text-gray-100 truncate">
-                      {ceremonyName(entry.exportData.ceremonyType)}
+                      {entry.exportData.teamName
+                        ? `${entry.exportData.teamName} · ${ceremonyName(entry.exportData.ceremonyType)}`
+                        : ceremonyName(entry.exportData.ceremonyType)}
                     </p>
                     <p className="text-xs text-gray-400 dark:text-gray-500">
                       {entry.exportData.date} · {t('history.steps', { done: entry.exportData.stepsCompleted, total: entry.exportData.totalSteps })}

--- a/src/i18n/be.json
+++ b/src/i18n/be.json
@@ -108,8 +108,13 @@
     "steps": "{{done}} з {{total}} крокаў",
     "view": "Прагляд",
     "resumePrompt": "Працягнуць {{ceremony}} з {{ago}} назад?",
+    "resumePromptTeam": "Працягнуць {{team}} · {{ceremony}} з {{ago}} назад?",
     "resume": "Працягнуць",
     "discard": "Адхіліць"
+  },
+  "team": {
+    "label": "Каманда / Пазнака (неабавязкова)",
+    "placeholder": "напр. Каманда Альфа"
   },
   "ceremonies": {
     "planning": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -108,8 +108,13 @@
     "steps": "{{done}} of {{total}} steps",
     "view": "View",
     "resumePrompt": "Resume {{ceremony}} from {{ago}}?",
+    "resumePromptTeam": "Resume {{team}} · {{ceremony}} from {{ago}}?",
     "resume": "Resume",
     "discard": "Discard"
+  },
+  "team": {
+    "label": "Team / Label (optional)",
+    "placeholder": "e.g. Team Alpha"
   },
   "ceremonies": {
     "planning": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -108,8 +108,13 @@
     "steps": "{{done}} de {{total}} pasos",
     "view": "Ver",
     "resumePrompt": "¿Reanudar {{ceremony}} desde hace {{ago}}?",
+    "resumePromptTeam": "¿Reanudar {{team}} · {{ceremony}} desde hace {{ago}}?",
     "resume": "Reanudar",
     "discard": "Descartar"
+  },
+  "team": {
+    "label": "Equipo / Etiqueta (opcional)",
+    "placeholder": "p. ej. Equipo Alfa"
   },
   "ceremonies": {
     "planning": {

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -108,8 +108,13 @@
     "steps": "{{done}} из {{total}} шагов",
     "view": "Просмотр",
     "resumePrompt": "Продолжить {{ceremony}} с {{ago}} назад?",
+    "resumePromptTeam": "Продолжить {{team}} · {{ceremony}} с {{ago}} назад?",
     "resume": "Продолжить",
     "discard": "Отменить"
+  },
+  "team": {
+    "label": "Команда / Метка (необязательно)",
+    "placeholder": "напр. Команда Альфа"
   },
   "ceremonies": {
     "planning": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export type RetroNotes = Record<string, StickyNote[]>
 export interface ExportData {
   ceremonyType: CeremonyType
   date: string
+  teamName?: string
   participants?: string[]
   retroNotes?: RetroNotes
   retroFormat?: RetroFormat
@@ -54,6 +55,7 @@ export interface SessionState {
   participants: Participant[]
   retroNotes: RetroNotes
   retroFormat?: RetroFormat
+  teamName?: string
   savedAt: number
 }
 


### PR DESCRIPTION
Implements #24: optional team/label input so facilitators running ceremonies for multiple Scrum teams can distinguish history entries.

## Changes
- `src/types.ts` — `teamName?: string` on `SessionState` and `ExportData`
- `src/App.tsx` — `scrum-facilitator-team-name` localStorage key; `recentTeamNames` derived from history
- `src/components/HomeScreen.tsx` — "Team / Label (optional)" text input with recent-name pill chips; history entries show `Team · Ceremony`; resume banner shows team name
- `src/components/CeremonyRunner.tsx` — `teamName` prop included in session auto-save and ceremony header
- `src/components/ExportView.tsx` — Markdown export title includes team name
- `src/i18n/en|es|be|ru.json` — `team.label`, `team.placeholder`, `history.resumePromptTeam` keys
- `.artefacts/BRIEF.md` — feature documented, localStorage keys section added

Automated agent commit — see BRIEF.md.