### PR TITLE
feat: add session summary fields for Dashboard integration (#15)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -39,13 +39,13 @@ Guided runner for Scrum ceremonies (planning, daily, review, retro): time-boxed 
 - [x] [#16] Feature: Keyboard shortcuts for ceremony runner — implemented
 - [x] [#17] Research: Mobile/tablet responsiveness — implemented
 - [x] [#24] Feature: Named ceremony history — label sessions by team/sprint — implemented
-- [ ] [#15] Integration: Dashboard card — surface active session and last ceremony
+- [x] [#15] Integration: Dashboard card — session key enriched with summary fields; dashboard card in agile-toolkit.github.io pending
 
 ## localStorage keys
 
 | Key | Content |
 |-----|---------|
-| `scrum-facilitator-session` | `{ ceremonyType, stepIndex, completedSteps, participants, retroNotes, retroFormat, teamName?, savedAt }` — auto-saved during ceremony, cleared on complete |
+| `scrum-facilitator-session` | `{ ceremonyType, stepIndex, totalSteps, currentStepId, completedSteps, participants, participantCount, retroNotes, retroNotesCount, retroFormat, teamName?, savedAt }` — auto-saved during ceremony; `participantCount`, `retroNotesCount`, `totalSteps`, `currentStepId` are pre-computed for easy dashboard reads |
 | `scrum-facilitator-history` | Array (max 5) of `{ id, exportData, savedAt }` — completed ceremony summaries |
 | `scrum-facilitator-retro-format` | `RetroFormat` string — selected retro format |
 | `scrum-facilitator-muted` | `'true'` or `'false'` — timer alert mute preference |
@@ -58,6 +58,11 @@ Guided runner for Scrum ceremonies (planning, daily, review, retro): time-boxed 
 - Root `README.md` still has HTML comment TODO for screenshots (non-blocking).
 
 ## Agent Log
+
+### 2026-06-09 — feat: session summary fields for Dashboard (#15, scrum-facilitator side)
+- Done: `types.ts` — added `totalSteps: number`, `currentStepId: string`, `participantCount: number`, `retroNotesCount: number` to `SessionState`; `CeremonyRunner.tsx` — session auto-save now computes and writes all four new fields alongside existing fields; BRIEF.md localStorage keys updated to document new shape
+- Remaining: dashboard card in `agile-toolkit.github.io` (issue #15 dashboard side — separate run targeting that repo)
+- Next task: check issues for human feedback on scrum-facilitator; research new opportunities if none pending
 
 ### 2026-06-07 — feat: named ceremony history (#24)
 - Done: `types.ts` — `teamName?: string` added to `SessionState` and `ExportData`; `App.tsx` — `scrum-facilitator-team-name` localStorage key via `useLocalStorage`, `recentTeamNames` derived from history, teamName passed to `HomeScreen` and `CeremonyRunner`; `HomeScreen.tsx` — "Team / Label (optional)" text input with recent-name pill chips; history entries show `Team · Ceremony` when team set; resume banner uses `resumePromptTeam` i18n key when teamName present; `CeremonyRunner.tsx` — `teamName` prop included in session auto-save and shown in ceremony header; `ExportView.tsx` — Markdown title includes team name; `en/es/be/ru.json` — `team.label`, `team.placeholder`, `history.resumePromptTeam` keys added

--- a/src/components/CeremonyRunner.tsx
+++ b/src/components/CeremonyRunner.tsx
@@ -95,12 +95,17 @@ export default function CeremonyRunner({
   // Auto-save session state on every meaningful change
   useEffect(() => {
     if (!ceremony) return
+    const retroNotesCount = Object.values(retroNotes).reduce((sum, notes) => sum + notes.length, 0)
     const session: SessionState = {
       ceremonyType,
       stepIndex,
+      totalSteps: ceremony.steps.length,
+      currentStepId: currentStep?.id ?? '',
       completedSteps,
       participants,
+      participantCount: participants.length,
       retroNotes,
+      retroNotesCount,
       retroFormat,
       teamName,
       savedAt: Date.now(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,9 +51,13 @@ export interface ExportData {
 export interface SessionState {
   ceremonyType: CeremonyType
   stepIndex: number
+  totalSteps: number
+  currentStepId: string
   completedSteps: number
   participants: Participant[]
+  participantCount: number
   retroNotes: RetroNotes
+  retroNotesCount: number
   retroFormat?: RetroFormat
   teamName?: string
   savedAt: number


### PR DESCRIPTION
Adds pre-computed summary fields to the `scrum-facilitator-session` localStorage key so the Dashboard card can read it without traversing arrays.

## Changes

- `types.ts` — `SessionState` gains `totalSteps`, `currentStepId`, `participantCount`, `retroNotesCount`
- `CeremonyRunner.tsx` — session auto-save computes all four fields on every save
- `BRIEF.md` — localStorage key schema updated; #15 marked partially done

## Summary fields added

| Field | Type | Source |
|-------|------|--------|
| `totalSteps` | `number` | `ceremony.steps.length` |
| `currentStepId` | `string` | `currentStep.id` (e.g. `planning-3`) |
| `participantCount` | `number` | `participants.length` |
| `retroNotesCount` | `number` | sum of all sticky notes across columns |

The dashboard-side card (`readScrumFacilitator()` + card component in `agile-toolkit.github.io`) is tracked in issue #15 and will be implemented in a separate run targeting that repo.

Automated agent commit — see BRIEF.md.